### PR TITLE
Add hint about auth tools in bearer middleware

### DIFF
--- a/src/lib/microsoft-auth.ts
+++ b/src/lib/microsoft-auth.ts
@@ -13,7 +13,11 @@ export const microsoftBearerTokenAuthMiddleware = (
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    res.status(401).json({ error: 'Missing or invalid access token' });
+    res.status(401).json({
+      error: 'Missing or invalid access token',
+      hint:
+        'If you intended to login via device code, start the server with --enable-auth-tools.'
+    });
     return;
   }
   


### PR DESCRIPTION
## Summary
- improve error message when auth header is missing by suggesting `--enable-auth-tools`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875dc9cce70832faba2ff33d871f39b